### PR TITLE
use temp files instead of RAM for generating the CSV files

### DIFF
--- a/bin/cmd/bundle/import.js
+++ b/bin/cmd/bundle/import.js
@@ -44,7 +44,7 @@ module.exports = {
     // create import stream
     process.stdin
       .pipe(stream.json.parse())
-      .pipe(stream.tar.createWriteStream())
+      .pipe(stream.bundle.createWriteStream())
       .pipe(stream.shell.duplex(compressor))
       .pipe(fs.createWriteStream(argv.file))
   }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   "dependencies": {
     "@turf/bbox": "^6.0.1",
     "better-sqlite3": "^5.4.3",
-    "convert-array-to-csv": "^1.0.9",
+    "csv-write-stream": "^2.0.0",
     "jsonstream2": "^3.0.0",
     "lodash": "^4.17.15",
     "mississippi2": "^1.0.5",
     "require-all": "^3.0.0",
     "rfc5646": "^3.0.0",
     "tar-stream": "^2.1.0",
+    "tmp": "^0.1.0",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/stream/bundle.js
+++ b/stream/bundle.js
@@ -1,0 +1,85 @@
+const _ = require('lodash')
+const fs = require('fs')
+const path = require('path')
+const tmp = require('tmp')
+const miss = require('mississippi2')
+const tar = require('tar-stream')
+const csv = require('csv-write-stream')
+const feature = require('../whosonfirst/feature')
+const file = require('../whosonfirst/file')
+const wofmeta = require('../whosonfirst/meta')
+const options = { objectMode: true, autoDestroy: true }
+
+module.exports.createWriteStream = (meta = true) => {
+  const pack = tar.pack()
+  const metadata = {}
+
+  // called once per feature
+  const xform = (feat, enc, next) => {
+    // find last modified time (not available for alt geometries)
+    const lastmodified = feature.getLastModified(feat)
+
+    // see: https://github.com/mafintosh/tar-stream#headers
+    const header = { name: path.join('data', file.path.fromFeature(feat)) }
+    if (lastmodified > 0) { header.mtime = new Date(feature.getLastModified(feat) * 1000) }
+
+    // add file to archive
+    pack.entry(header, JSON.stringify(feat))
+
+    // generate meta file(s)
+    // note: temp files are used to avoid storing in RAM
+    if (meta === true) {
+      const placetype = feature.getPlacetype(feat)
+
+      // note: alt geometries have no placetype
+      if (placetype && placetype !== 'unknown') {
+        // create a new tempfile for this placetype
+        if (!_.has(metadata, placetype)) {
+          const tmpFileName = tmp.tmpNameSync()
+          const store = {
+            path: tmpFileName,
+            writable: miss.pipeline.obj(
+              csv(),
+              fs.createWriteStream(tmpFileName)
+            )
+          }
+          metadata[placetype] = store
+        }
+        // write a row to the tempfile
+        metadata[placetype].writable.write(wofmeta(feat))
+      }
+    }
+
+    next()
+  }
+
+  // called at the end
+  const flush = (done) => {
+
+    // write meta file(s)
+    if (meta === true) {
+      _.each(metadata, (store, placetype) => {
+
+        // end writing to file
+        store.writable.end()
+
+        // write CSV meta files
+        // @todo: try getting this to work with pure streams?
+        const header = { name: path.join('meta', `${placetype}.csv`) }
+        pack.entry(header, fs.readFileSync(store.path))
+
+        // remove temp file
+        fs.unlinkSync(store.path)
+      })
+    }
+
+    pack.finalize()
+    done()
+  }
+
+  // create tranform proxy
+  const proxy = miss.through(options, xform, flush)
+
+  // return duplex stream
+  return miss.duplex(proxy, pack, options)
+}

--- a/stream/tar.js
+++ b/stream/tar.js
@@ -1,11 +1,5 @@
-const _ = require('lodash')
-const path = require('path')
 const miss = require('mississippi2')
 const tar = require('tar-stream')
-const csv = require('convert-array-to-csv')
-const feature = require('../whosonfirst/feature')
-const file = require('../whosonfirst/file')
-const wofmeta = require('../whosonfirst/meta')
 const options = { objectMode: true, autoDestroy: true }
 
 module.exports.createReadStream = (filter) => {
@@ -36,61 +30,4 @@ module.exports.createReadStream = (filter) => {
 
   // return duplex stream
   return miss.duplex(extract, proxy, options)
-}
-
-module.exports.createWriteStream = (meta = true) => {
-  const pack = tar.pack()
-  const metadata = {}
-
-  // called once per feature
-  const xform = (feat, enc, next) => {
-    // find last modified time (not available for alt geometries)
-    const lastmodified = feature.getLastModified(feat)
-
-    // see: https://github.com/mafintosh/tar-stream#headers
-    const header = { name: path.join('data', file.path.fromFeature(feat)) }
-    if (lastmodified > 0) { header.mtime = new Date(feature.getLastModified(feat) * 1000) }
-
-    // add file to archive
-    pack.entry(header, JSON.stringify(feat))
-
-    // generate meta file(s)
-    // @todo: is it safe to store this in RAM?
-    if (meta === true) {
-      const placetype = feature.getPlacetype(feat)
-
-      // alt geometries have no placetype
-      if (placetype) {
-        if (!metadata[placetype]) { metadata[placetype] = [] }
-        metadata[placetype].push(wofmeta(feat))
-      }
-    }
-
-    next()
-  }
-
-  // called at the end
-  const flush = (done) => {
-    // write meta file(s)
-    if (meta === true) {
-      _.each(metadata, (rows, placetype) => {
-        // skip empty files
-        if (!_.isArray(rows) || _.isEmpty(rows)) { return }
-
-        // write CSV meta files
-        // @todo: in a more memory efficient way
-        const header = { name: path.join('meta', `${placetype}.csv`) }
-        pack.entry(header, csv.convertArrayToCSV(rows))
-      })
-    }
-
-    pack.finalize()
-    done()
-  }
-
-  // create tranform proxy
-  const proxy = miss.through(options, xform, flush)
-
-  // return duplex stream
-  return miss.duplex(proxy, pack, options)
 }


### PR DESCRIPTION
use temp files instead of RAM for generating the meta CSV files for bundles