### PR TITLE
fix bbox calcs, add unit tests

### DIFF
--- a/whosonfirst/file.test.js
+++ b/whosonfirst/file.test.js
@@ -8,7 +8,7 @@ module.exports.interface = (test) => {
   })
 }
 
-module.exports.fromFeature = (test) => {
+module.exports.fromID = (test) => {
   test('fromID', (t) => {
     t.equal(file.path.fromID(1), '1/1.geojson')
     t.equal(file.path.fromID(12), '12/12.geojson')
@@ -35,6 +35,9 @@ module.exports.fromFeature = (test) => {
     t.equal(file.path.fromID(1234567890, 'example'), '123/456/789/0/1234567890-alt-example.geojson')
     t.end()
   })
+}
+
+module.exports.fromFeature = (test) => {
   test('fromFeature', (t) => {
     t.equal(file.path.fromFeature({ properties: { 'wof:id': 1 } }), '1/1.geojson')
     t.equal(file.path.fromFeature({ properties: { 'wof:id': 12 } }), '12/12.geojson')

--- a/whosonfirst/geometry.js
+++ b/whosonfirst/geometry.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const feature = require('./feature')
 const bounds = require('@turf/bbox').default
 const nullIsland = [0, 0, 0, 0]
@@ -5,7 +6,7 @@ const nullIsland = [0, 0, 0, 0]
 // [minX, minY, maxX, maxY]
 module.exports.bbox = (feat, useGeometry) => {
   // parse 'geom:bbox' property (fast)
-  let bbox = feature.get(feat, 'properties.geom:bbox', '').split(',').filter(Number)
+  let bbox = feature.get(feat, 'properties.geom:bbox', '').split(',').map(parseFloat).filter(_.isFinite)
 
   // use geometry bounds when property not available
   if (bbox.length !== 4) { useGeometry = true }
@@ -14,7 +15,7 @@ module.exports.bbox = (feat, useGeometry) => {
   if (useGeometry === true) { bbox = bounds(feat) }
 
   // valid bbox
-  if (bbox.filter(Number).length === 4) { return bbox }
+  if (bbox.filter(_.isFinite).length === 4) { return bbox }
 
   // invalid bbox
   console.error(`invalid bbox for feature ${feature.getID(feat)}: ${bbox}`)

--- a/whosonfirst/geometry.test.js
+++ b/whosonfirst/geometry.test.js
@@ -1,0 +1,60 @@
+const geometry = require('./geometry')
+
+module.exports.interface = (test) => {
+  test('interface', (t) => {
+    t.true(geometry.bbox)
+    t.end()
+  })
+}
+
+module.exports.bbox = (test) => {
+  test('bbox - from properties', (t) => {
+    t.deepEquals(geometry.bbox({
+      properties: {
+        'geom:bbox': '1.1,2.2,3.3,4.4'
+      }
+    }), [1.1, 2.2, 3.3, 4.4])
+    t.end()
+  })
+  test('bbox - from properties - null island', (t) => {
+    t.deepEquals(geometry.bbox({
+      properties: {
+        'geom:bbox': '0,0,0,0'
+      }
+    }), [0, 0, 0, 0])
+    t.end()
+  })
+  test('bbox - from geometry', (t) => {
+    t.deepEquals(geometry.bbox({
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [[1.1, 2.2], [3.3, 4.4]]
+      }
+    }), [1.1, 2.2, 3.3, 4.4])
+    t.end()
+  })
+  test('bbox - from geometry - null island', (t) => {
+    t.deepEquals(geometry.bbox({
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [0, 0]
+      }
+    }), [0, 0, 0, 0])
+    t.end()
+  })
+  test('bbox - force geometry', (t) => {
+    t.deepEquals(geometry.bbox({
+      type: 'Feature',
+      properties: {
+        'geom:bbox': '1.1,2.2,3.3,4.4'
+      },
+      geometry: {
+        type: 'LineString',
+        coordinates: [[5.5, 6.6], [7.7, 8.8]]
+      }
+    }, true), [5.5, 6.6, 7.7, 8.8])
+    t.end()
+  })
+}


### PR DESCRIPTION
fix bbox calcs, add unit tests, because apparently:

```
'100.4,0,100.4,0'.split(',').filter(Number)

(2) ["100.4", "100.4"]
```