### PR TITLE
find cmd via child_process do not need semicolon escape

### DIFF
--- a/bin/cmd/fs/export.js
+++ b/bin/cmd/fs/export.js
@@ -22,7 +22,7 @@ module.exports = {
   handler: (argv) => {
     let args = [argv.path, '-type', 'f', '-name', '*.geojson']
     if (!argv.alt) { args = [...args, '!', '-name', '*-alt-*'] }
-    args = [...args, '-exec', 'cat', '{}', '\\;'] // print contents instead of filenames
+    args = [...args, '-exec', 'cat', '{}', ';'] // print contents instead of filenames
 
     // create export stream
     stream.find(...args)

--- a/bin/cmd/fs/list.js
+++ b/bin/cmd/fs/list.js
@@ -37,9 +37,9 @@ module.exports = {
 
     // path normalization
     if (argv.normalization === 'realpath') {
-      args = [...args, '-exec', 'realpath', '--relative-to', argv.path, '{}', '\\;']
+      args = [...args, '-exec', 'realpath', '--relative-to', argv.path, '{}', ';']
     } else if (argv.normalization === 'basename') {
-      args = [...args, '-exec', 'basename', '{}', '\\;']
+      args = [...args, '-exec', 'basename', '{}', ';']
     }
 
     // create export stream


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

When I use the fs sub command, it fails with this message: 

```
$ wof fs export data
find: missing argument to `-exec'
```

---
#### Here's what actually got changed :clap:

I've remove the semicolon escape from the spawn, it seems to be the cause of the issue. Check if it's also ok for you.

I tried on debian jessie and buster.