### PR TITLE
use WOF convention for naming meta files

### DIFF
--- a/bin/cmd/bundle/import.js
+++ b/bin/cmd/bundle/import.js
@@ -20,6 +20,16 @@ module.exports = {
       alias: 'rm',
       describe: 'Delete db file before import if it already exists.'
     })
+    yargs.option('collection', {
+      type: 'string',
+      default: undefined,
+      describe: `Name of the collection, such as 'whosonfirst-data' or 'whosonfirst-data-macroregion'`
+    })
+    yargs.option('version', {
+      type: 'string',
+      default: undefined,
+      describe: `Name of the version, such as 'latest' or '1535390738'`
+    })
   },
   handler: (argv) => {
     // auto-detect format
@@ -44,7 +54,7 @@ module.exports = {
     // create import stream
     process.stdin
       .pipe(stream.json.parse())
-      .pipe(stream.bundle.createWriteStream())
+      .pipe(stream.bundle.createWriteStream({ collection: argv.collection, version: argv.version }))
       .pipe(stream.shell.duplex(compressor))
       .pipe(fs.createWriteStream(argv.file))
   }

--- a/whosonfirst/convention.js
+++ b/whosonfirst/convention.js
@@ -1,0 +1,11 @@
+
+// default values
+module.exports.default = {}
+module.exports.default.collection = 'whosonfirst-data'
+module.exports.default.version = 'latest'
+
+// this is the name of the meta/xxx.csv files generated in bundles
+// eg. whosonfirst-data-ocean-latest.csv
+module.exports.metaFilename = (collection, placetype, version) => {
+  return `${collection}-${placetype}-${version}.csv`
+}


### PR DESCRIPTION
resolves issue https://github.com/pelias/whosonfirst/issues/479

This PR adds a new `convention.js` file which is a place to document WOF conventions for naming/etc.

I've also updated the `bundle import` command to take `--collection=` and `--version=` arguments which alter the name of the meta files which get generated.