### PR TITLE
correct implementation of a duplex stream for a child process

### DIFF
--- a/bin/cmd/bundle/import.js
+++ b/bin/cmd/bundle/import.js
@@ -34,6 +34,7 @@ module.exports = {
   handler: (argv) => {
     // auto-detect format
     let compressor
+    // @todo add support for lbzip2 and pigz
     if (argv.file.endsWith('tar.bz2')) { compressor = 'bzip2' }
     if (argv.file.endsWith('tar.gz')) { compressor = 'gzip' }
     if (argv.file.endsWith('tar')) { compressor = 'cat' }

--- a/stream/bsdtar.js
+++ b/stream/bsdtar.js
@@ -6,7 +6,8 @@ module.exports.extract = (...args) => shell.duplex(
 )
 
 // man page: the file listing will be written to stderr rather than the usual stdout
-module.exports.list = (...args) => shell.duplexStderr(
-  'bsdtar',
-  ['-tOf', '-', ...args]
+// the bash-foo is used in order to 'switch' stderr and stderr streams
+module.exports.list = (...args) => shell.duplex(
+  'bash',
+  ['-c', `set -o noglob; 3>&1 1>&2 2>&3 bsdtar -tOf - ` + args.join(' ')]
 )

--- a/stream/git.js
+++ b/stream/git.js
@@ -26,8 +26,7 @@ module.exports.archive = (dir, tree, filterPath, args) => {
   return miss.pipeline(
     shell.duplex(
       'git',
-      [`--git-dir=${dir}`, 'archive', tree, filterPath],
-      { stdio: ['ignore', 'pipe', 'inherit'] }
+      [`--git-dir=${dir}`, 'archive', tree, filterPath]
     ),
     bsdtar.extract(...args)
   )

--- a/stream/shell.js
+++ b/stream/shell.js
@@ -1,37 +1,13 @@
 const _ = require('lodash')
 const child = require('child_process')
-const miss = require('mississippi2')
-const defaults = { env: process.env }
+const spawnDuplex = require('./spawnDuplex')
 
 module.exports.spawn = (cmd, args, options) => {
   return child.spawn(
     cmd,
     _.isArray(args) ? args : [],
-    _.defaults({}, defaults, options)
+    _.defaults({}, options)
   )
 }
 
-// module.exports.duplex = (cmd, args, options) => miss.child.spawn(cmd, args)
-
-module.exports.duplex = (cmd, args, options) => {
-  const proc = module.exports.spawn(cmd, args, _.defaults({
-    stdio: ['pipe', 'pipe', 'inherit']
-  }, options))
-
-  // handle close event
-  proc.stdin.once('close', () => proc.stdin.end())
-
-  return miss.duplex(proc.stdin, proc.stdout)
-}
-
-// same as above but output is on stderr instead of stdout
-module.exports.duplexStderr = (cmd, args, options) => {
-  const proc = module.exports.spawn(cmd, args, _.defaults({
-    stdio: ['pipe', 'inherit', 'pipe']
-  }, options))
-
-  // handle close event
-  proc.stdin.once('close', () => proc.stdin.end())
-
-  return miss.duplex(proc.stdin, proc.stderr)
-}
+module.exports.duplex = (cmd, args) => spawnDuplex(cmd, args)

--- a/stream/spawnDuplex.js
+++ b/stream/spawnDuplex.js
@@ -1,0 +1,78 @@
+// https://github.com/junosuarez/exec-stream/pull/2
+
+const Stream = require('stream')
+const spawn = require('child_process').spawn
+
+// optionally increase the internal buffer (up from 64KB)
+// this is a tradeoff between using more RAM for the
+// buffer and having more frequent stop/starts of
+// the subprocess due to back-pressure.
+// note: my testing showed no benefit in increasing this
+const streamOptions = {
+  // highWaterMark: 1e+6 // 1MB
+}
+
+function spawnDuplex(cmd, args, options) {
+
+  const AB = new Stream.Duplex(streamOptions)
+  const A = new Stream.PassThrough(streamOptions)
+  const B = new Stream.PassThrough(streamOptions)
+
+  // keep track of signal state
+  // see: https://github.com/junosuarez/exec-stream/pull/2
+  let SIGSTOP = false
+
+  AB._write = (chunk, encoding, cb) => {
+    return A.write(chunk, encoding, cb)
+  }
+
+  AB.on('finish', () => {
+    A.end()
+  })
+
+  AB._read = function (n) {
+    // send SIGCONT to continue
+    if (SIGSTOP) {
+      SIGSTOP = false
+      proc.kill('SIGCONT')
+    }
+  }
+
+  B.on('readable', () => {
+    // send SIGSTOP to handle backpressure
+    if (!AB.push(B.read()) && !SIGSTOP){
+      SIGSTOP = true
+      proc.kill('SIGSTOP')
+    }
+  })
+
+  B.on('end', () => {
+    AB.push(null)
+  })
+
+  B.on('error', (err) => {
+    AB.emit('error', err)
+  })
+
+  A.on('error', (err) => {
+    AB.emit('error', err)
+  })
+
+  // spawn the child process
+  const proc = spawn(cmd, args, options)
+
+  // connect pipes
+  A.pipe(proc.stdin)
+  proc.stdout.pipe(B)
+
+  // do not discard stderr stream, send to process
+  proc.stderr.pipe(process.stderr)
+
+  proc.on('error', (err) => {
+    AB.emit('error', err)
+  })
+
+  return AB
+}
+
+module.exports = spawnDuplex


### PR DESCRIPTION
ok, so this is something I've been trying to get right for years and none of the libraries I found are doing it correctly!
it's based heavily on the implementation in https://github.com/junosuarez/exec-stream/pull/2

the new `spawnDuplex` stream returns a nodejs stream which is connected to `stdin` and `stdout` of a spawned child process.
... and the important bit is that it handles flow-control correctly.

with all other implementations I found, if you have a fast writer and a slow reader then all of the `stdout` from the writer is buffered in the nodejs memory waiting for the reader to ask for more. this will eventually result in OOM errors.

this implementation uses the `SIGSTOP` and `SIGCONT` kill signals to put the child process to sleep when the highwatermark is reached and wakes it up again when the reader is ready for more data 🎉 