### PR TITLE
use "src:alt_label" in preference to "src:geom" when available

### DIFF
--- a/sqlite/table/geojson.test.js
+++ b/sqlite/table/geojson.test.js
@@ -89,7 +89,34 @@ module.exports.insert = (test) => {
     t.deepEquals(db.stmt[0].action.run[0], [{
       id: -1,
       body: '{"type":"Feature","properties":{"src:alt_label":"test"},"geometry":{"type":"Point","coordinates":[0,0]}}',
-      source: 'unknown',
+      source: 'test',
+      is_alt: 1,
+      lastmodified: -1
+    }])
+
+    t.end()
+  })
+  // https://github.com/whosonfirst-data/whosonfirst-data/issues/1834
+  test('insert - prefer the src:alt_label over src:geom when both available', (t) => {
+    const db = new MockDatabase()
+    const insert = geojson.insert(db)
+
+    insert({
+      type: 'Feature',
+      properties: {
+        'src:alt_label': 'test2',
+        'src:geom': 'test'
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [0, 0]
+      }
+    })
+
+    t.deepEquals(db.stmt[0].action.run[0], [{
+      id: -1,
+      body: '{"type":"Feature","properties":{"src:alt_label":"test2","src:geom":"test"},"geometry":{"type":"Point","coordinates":[0,0]}}',
+      source: 'test2',
       is_alt: 1,
       lastmodified: -1
     }])

--- a/whosonfirst/feature.js
+++ b/whosonfirst/feature.js
@@ -9,13 +9,14 @@ feature.get = _.get
 
 feature.getID = (feat) => _.get(feat, 'properties.wof:id', -1)
 feature.getPlacetype = (feat) => _.get(feat, 'properties.wof:placetype', 'unknown')
-feature.getSource = (feat) => _.get(feat, 'properties.src:geom', 'unknown')
+feature.getSource = (feat) => feature.getAltLabel(feat) || feature.getGeomSource(feat)
 feature.getParentId = (feat) => _.get(feat, 'properties.wof:parent_id', -1)
 feature.getName = (feat) => _.get(feat, 'properties.wof:name', '')
 feature.getCountry = (feat) => _.get(feat, 'properties.wof:country', 'XX')
 feature.getISO = (feat) => _.get(feat, 'properties.iso:country', 'XX')
 feature.getRepo = (feat) => _.get(feat, 'properties.wof:repo', 'whosonfirst-data-xx')
 feature.getAltLabel = (feat) => _.get(feat, 'properties.src:alt_label')
+feature.getGeomSource = (feat) => _.get(feat, 'properties.src:geom', 'unknown')
 
 feature.getIsCurrent = (feat) => _.get(feat, 'properties.mz:is_current', -1)
 feature.getDeprecated = (feat) => _.get(feat, 'properties.edtf:deprecated', 'uuuu')

--- a/whosonfirst/feature.test.js
+++ b/whosonfirst/feature.test.js
@@ -1,0 +1,27 @@
+const feature = require('./feature')
+
+module.exports.interface = (test) => {
+  test('interface', (t) => {
+    t.true(feature.getSource)
+    t.end()
+  })
+}
+
+// https://github.com/whosonfirst-data/whosonfirst-data/issues/1834
+module.exports.getSource = (test) => {
+  test('getSource', (t) => {
+    t.equal('unknown', feature.getSource({}))
+    t.equal('GEOM_SRC', feature.getSource({
+      properties: {
+        'src:geom': 'GEOM_SRC'
+      }
+    }))
+    t.equal('ALT_LABEL', feature.getSource({
+      properties: {
+        'src:geom': 'GEOM_SRC',
+        'src:alt_label': 'ALT_LABEL'
+      }
+    }))
+    t.end()
+  })
+}

--- a/whosonfirst/meta.js
+++ b/whosonfirst/meta.js
@@ -28,7 +28,7 @@ module.exports = (feat) => {
     path: file.path.fromFeature(feat),
     placetype: feature.getPlacetype(feat),
     region_id: getHierarchyID(feat, 'region'),
-    source: feature.getSource(feat),
+    source: feature.getGeomSource(feat),
     superseded_by: feature.getSupersededBy(feat).join(','),
     supersedes: feature.getSupersedes(feat).join(','),
     wof_country: feature.getCountry(feat)


### PR DESCRIPTION
PR to resolve issue outlined in https://github.com/whosonfirst-data/whosonfirst-data/issues/1834

Use "src:alt_label" in preference to "src:geom" when available for `geojson.source` field in SQLite db.

I'm not quite sure what's preferable for the "source" column in the meta files so I kept them the same (using "src:geom") 🤷 

related: https://github.com/pelias/docker/issues/192