### PR TITLE
improved centroid calc for SPR

### DIFF
--- a/whosonfirst/geometry.js
+++ b/whosonfirst/geometry.js
@@ -4,7 +4,7 @@ const bounds = require('@turf/bbox').default
 const nullIsland = [0, 0, 0, 0]
 
 // [minX, minY, maxX, maxY]
-module.exports.bbox = (feat, useGeometry) => {
+function bbox (feat, useGeometry) {
   // parse 'geom:bbox' property (fast)
   let bbox = feature.get(feat, 'properties.geom:bbox', '').split(',').map(parseFloat).filter(_.isFinite)
 
@@ -21,3 +21,31 @@ module.exports.bbox = (feat, useGeometry) => {
   console.error(`invalid bbox for feature ${feature.getID(feat)}: ${bbox}`)
   return nullIsland
 }
+
+// compute center of bbox
+// note: this is really inacurate for anything crossing the antimeridian, avoid using it
+// function centroidFromBbox (feat) {
+//   const bounds = bbox(feat)
+//   return {
+//     lon: (bounds[0] + ((bounds[2] - bounds[0]) / 2)),
+//     lat: (bounds[1] + ((bounds[3] - bounds[1]) / 2))
+//   }
+// }
+
+// search properties for a valid centroid, returning the first one found
+function centroidProperty (feat, namespaces) {
+  for (var i = 0; i < namespaces.length; i++) {
+    const lon = parseFloat(feature.get(feat, `properties.${namespaces[i]}:longitude`))
+    const lat = parseFloat(feature.get(feat, `properties.${namespaces[i]}:latitude`))
+    if (!isNaN(lon) && !isNaN(lat)) {
+      return { lon, lat }
+    }
+  }
+}
+
+// https://github.com/whosonfirst/go-whosonfirst-geojson-v2/blob/master/properties/whosonfirst/whosonfirst.go#L71
+function centroid (feat) {
+  return centroidProperty(feat, ['lbl', 'reversegeo', 'geom']) || { lon: 0, lat: 0 }
+}
+
+module.exports = { bbox, centroid }

--- a/whosonfirst/geometry.test.js
+++ b/whosonfirst/geometry.test.js
@@ -58,3 +58,70 @@ module.exports.bbox = (test) => {
     t.end()
   })
 }
+
+module.exports.centroid = (test) => {
+  test('centroid - default', (t) => {
+    t.deepEquals(geometry.centroid({}), { lon: 0, lat: 0 })
+    t.end()
+  })
+  test('centroid - both namespace properties must be set', (t) => {
+    t.deepEquals(geometry.centroid({
+      properties: {
+        'geom:longitude': 1.1
+      }
+    }), { lon: 0, lat: 0 })
+    t.end()
+  })
+  test('centroid - both namespace properties must be valid', (t) => {
+    t.deepEquals(geometry.centroid({
+      properties: {
+        'geom:longitude': 1.1,
+        'geom:latitude': 'a'
+      }
+    }), { lon: 0, lat: 0 })
+    t.end()
+  })
+  test('centroid - namespace properties can be strings', (t) => {
+    t.deepEquals(geometry.centroid({
+      properties: {
+        'geom:longitude': '1.1',
+        'geom:latitude': '2.2'
+      }
+    }), { lon: 1.1, lat: 2.2 })
+    t.end()
+  })
+
+  test('centroid - use "geom" namespace where available', (t) => {
+    t.deepEquals(geometry.centroid({
+      properties: {
+        'geom:longitude': 1.1,
+        'geom:latitude': 2.2
+      }
+    }), { lon: 1.1, lat: 2.2 })
+    t.end()
+  })
+  test('centroid - prefer "reversegeo" namespace', (t) => {
+    t.deepEquals(geometry.centroid({
+      properties: {
+        'geom:longitude': 1.1,
+        'geom:latitude': 2.2,
+        'reversegeo:longitude': 3.3,
+        'reversegeo:latitude': 4.4
+      }
+    }), { lon: 3.3, lat: 4.4 })
+    t.end()
+  })
+  test('centroid - prefer "lbl" namespace', (t) => {
+    t.deepEquals(geometry.centroid({
+      properties: {
+        'geom:longitude': 1.1,
+        'geom:latitude': 2.2,
+        'reversegeo:longitude': 3.3,
+        'reversegeo:latitude': 4.4,
+        'lbl:longitude': 5.5,
+        'lbl:latitude': 6.6
+      }
+    }), { lon: 5.5, lat: 6.6 })
+    t.end()
+  })
+}

--- a/whosonfirst/spr.js
+++ b/whosonfirst/spr.js
@@ -28,9 +28,10 @@ module.exports = (feat) => {
 function coordinates (feat) {
   // [minX, minY, maxX, maxY]
   const bbox = geometry.bbox(feat)
+  const centroid = geometry.centroid(feat)
   return {
-    latitude: (bbox[1] + ((bbox[3] - bbox[1]) / 2)),
-    longitude: (bbox[0] + ((bbox[2] - bbox[0]) / 2)),
+    latitude: centroid.lat,
+    longitude: centroid.lon,
     min_latitude: bbox[1],
     min_longitude: bbox[0],
     max_latitude: bbox[3],


### PR DESCRIPTION
I noticed that the `latitude` and `longitude` values in the `SPR` table of the `SQLite` databases are pretty broken for any feature which crosses the antimeridian (such as NZ being at `-40.6242455|0.842041000000023`).

This PR uses a centroid property when available instead of using the bbox to calculate the centroid.