### PR TITLE
update better-sqlite3 to modern version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@turf/bbox": "^6.0.1",
-    "better-sqlite3": "^6.0.1",
+    "better-sqlite3": "^7.4.3",
     "combine-streams": "^1.0.0",
     "command-exists": "^1.2.8",
     "csv-write-stream": "^2.0.0",

--- a/sqlite/table/geojson.test.js
+++ b/sqlite/table/geojson.test.js
@@ -129,7 +129,7 @@ module.exports.insert = (test) => {
   })
   // https://github.com/whosonfirst/go-whosonfirst-sqlite-features/issues/7
   test('insert - improved unique constraint', (t) => {
-    const db = new Database('/tmp/foo', { memory: true })
+    const db = new Database(':memory:')
     geojson.create(db)
     geojson.createIndices(db)
 


### PR DESCRIPTION
upgrading `better-sqlite3` is required for the `sqlite` functions to work on modern node versions (such as `v16.4.2` which I was running when I got this error):

```bash
npm i -g '@whosonfirst/wof@latest'

npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'stream-from-value@0.1.0',
npm WARN EBADENGINE   required: { node: '^0.11 || ^0.10' },
npm WARN EBADENGINE   current: { node: 'v16.4.2', npm: '7.18.1' }
npm WARN EBADENGINE }
npm ERR! code 1
npm ERR! path /usr/local/lib/node_modules/@whosonfirst/wof/node_modules/integer
npm ERR! command failed
npm ERR! command sh -c prebuild-install || npm run build-release
npm ERR! > integer@3.0.1 build-release
npm ERR! > node-gyp rebuild --release
npm ERR!
npm ERR!   CXX(target) Release/obj.target/integer/src/integer.o
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@16.4.2 | darwin | x64
npm ERR! gyp info find Python using Python version 3.9.5 found at "/usr/local/opt/python@3.9/bin/python3.9"
npm ERR! (node:26050) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
npm ERR! (Use `node --trace-deprecation ...` to show where the warning was created)
npm ERR! gyp info spawn /usr/local/opt/python@3.9/bin/python3.9
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args   '/usr/local/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/local/lib/node_modules/@whosonfirst/wof/node_modules/integer/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/local/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/Users/peter/Library/Caches/node-gyp/16.4.2/include/node/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/Users/peter/Library/Caches/node-gyp/16.4.2',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/usr/local/lib/node_modules/npm/node_modules/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/Users/peter/Library/Caches/node-gyp/16.4.2/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/usr/local/lib/node_modules/@whosonfirst/wof/node_modules/integer',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! gyp info spawn make
npm ERR! gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm ERR! In file included from ../src/integer.cpp:1:
npm ERR! In file included from ../src/integer.hpp:3:
npm ERR! In file included from /Users/peter/Library/Caches/node-gyp/16.4.2/include/node/node.h:63:
npm ERR! In file included from /Users/peter/Library/Caches/node-gyp/16.4.2/include/node/v8.h:30:
npm ERR! /Users/peter/Library/Caches/node-gyp/16.4.2/include/node/v8-internal.h:454:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
npm ERR!             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
npm ERR!                                 ~~~~~^~~~~~~~~~~
npm ERR!                                      remove_cv
npm ERR! /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
npm ERR! template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
npm ERR!                                                  ^
npm ERR! 1 error generated.
npm ERR! make: *** [Release/obj.target/integer/src/integer.o] Error 1
npm ERR! gyp ERR! build error
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:394:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
npm ERR! gyp ERR! System Darwin 19.6.0
npm ERR! gyp ERR! command "/usr/local/Cellar/node/16.4.2/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--release"
npm ERR! gyp ERR! cwd /usr/local/lib/node_modules/@whosonfirst/wof/node_modules/integer
npm ERR! gyp ERR! node -v v16.4.2
npm ERR! gyp ERR! node-gyp -v v7.1.2
npm ERR! gyp ERR! not ok

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/peter/.npm/_logs/2021-07-27T16_50_00_216Z-debug.log
```