### PR TITLE
improved error handling/reporting

### DIFF
--- a/bin/middleware.js
+++ b/bin/middleware.js
@@ -1,0 +1,31 @@
+const PrettyError = require('pretty-error')
+
+/**
+ * The uncaughtExceptionMiddleware registers a global
+ * 'uncaughtException' handler which catches any otherwise
+ * uncaught errors.
+ */
+const uncaughtExceptionMiddleware = (argv) => {
+  // Register the global error handler
+  process.on('uncaughtException', (err) => {
+    // Gracefully swallow EPIPE and SIGPIPE signals such
+    // as when STDOUT is piped to a process which exits
+    // prematurely. ie 'wof ... | head'.
+    if (err && (err.code === 'EPIPE' || err.code === 'SIGPIPE')) {
+      process.exitCode = 0
+      return
+    }
+
+    // Set error code
+    process.exitCode = 1
+
+    // Print a pretty error message
+    console.error(new PrettyError().render(err))
+
+    // Allow the program to exit naturally..
+  })
+}
+
+module.exports = [
+  uncaughtExceptionMiddleware
+]

--- a/bin/wof.js
+++ b/bin/wof.js
@@ -3,6 +3,7 @@
 require('yargs')
   .scriptName('wof')
   .usage('$0 <cmd> [args]')
+  .middleware(require('./middleware'))
   // .completion('completion')
   .option('verbose', {
     type: 'boolean',
@@ -11,6 +12,7 @@ require('yargs')
     describe: 'enable verbose logging'
   })
   .commandDir('cmd')
+  .strict()
   .showHelpOnFail(true)
   .demandCommand(1, '')
   .help()

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jsonstream2": "^3.0.0",
     "lodash": "^4.17.15",
     "mississippi2": "^1.0.5",
+    "pretty-error": "^3.0.4",
     "require-all": "^3.0.0",
     "rfc5646": "^3.0.0",
     "tar-stream": "^2.1.2",


### PR DESCRIPTION
this PR improves the error handling:
- swallow `EPIPE` and `SIGPIPE` to avoid ugly errors when the downstream pipe disconnects prematurely
- enable yargs option [.strict()](https://yargs.js.org/docs/#api-reference-strictenabledtrue) to error on an unknown CLI command (previously it would render nothing and `exit(0)`
- print pretty errors with the help of `npm pretty-error`