### PR TITLE
git: add clone command

### DIFF
--- a/stream/git.js
+++ b/stream/git.js
@@ -31,3 +31,26 @@ module.exports.archive = (dir, tree, filterPath, args) => {
     bsdtar.extract(...args)
   )
 }
+
+module.exports.clone_strategies = ['standard', 'shallow', 'bare']
+module.exports.clone = (strategy, uri, dir, branch) => {
+  const flags = [
+    '--progress',
+    '--branch', branch
+  ]
+
+  // limit the clone depth for all non-standard strategies
+  if (strategy !== 'standard') {
+    flags.push(
+      '--depth', '1',
+      '--single-branch'
+    )
+  }
+
+  // perform a 'bare' clone (ie. no working copy of the files)
+  if (strategy === 'bare') {
+    flags.push('--bare')
+  }
+
+  return shell.spawn('git', ['clone', ...flags, uri, dir], { stdio: 'inherit' })
+}


### PR DESCRIPTION
add a `wof git clone` command which handles some different clone strategies out-of-the-box:

```bash
wof git clone --help

wof git clone <uri> <repo>

clone a remote git repository

Positionals:
  uri   Address of the remote git repository.                [string] [required]
  repo  Local path to write git repository.                  [string] [required]

Options:
  --version      Show version number                                   [boolean]
  --verbose, -v  enable verbose logging               [boolean] [default: false]
  --help         Show help                                             [boolean]
  --strategy
          [string] [choices: "standard", "shallow", "bare"] [default: "shallow"]
  --branch       The remote branch to clone.        [string] [default: "master"]
  --base         The base URL to resolve against if uri is not absolute.
                      [string] [default: "https://github.com/whosonfirst-data/"]
```

example:

```bash
wof git clone --strategy=bare whosonfirst-data-admin-nz /tmp/nz

Cloning [bare] https://github.com/whosonfirst-data/whosonfirst-data-admin-nz
Cloning into bare repository '/tmp/nz'...
remote: Enumerating objects: 26654, done.
remote: Counting objects: 100% (26654/26654), done.
remote: Compressing objects: 100% (14331/14331), done.
remote: Total 26654 (delta 3616), reused 19877 (delta 2776), pack-reused 0
Receiving objects: 100% (26654/26654), 123.30 MiB | 12.93 MiB/s, done.
Resolving deltas: 100% (3616/3616), done.
```