### PR TITLE
import: fix encoding issue with the FS import command

### DIFF
--- a/bin/cmd/fs/import.js
+++ b/bin/cmd/fs/import.js
@@ -33,7 +33,11 @@ module.exports = {
         fs.mkdirSync(path.dirname(fullpath), { recursive: true })
 
         // optionally 'exportify' the record
-        if (argv.exportify) { feat = exportify(feat) }
+        if (argv.exportify) {
+          feat = exportify(feat)
+        } else {
+          feat = JSON.stringify(feat, null, 2)
+        }
 
         if (argv.verbose) { console.error(`write ${fullpath}`) }
         fs.writeFileSync(fullpath, feat)


### PR DESCRIPTION
this PR fixes an issue with the `fs import` command where the feature wasn't being correctly JSON encoded