### PR TITLE
add script to fix missing concordances

### DIFF
--- a/bin/cmd/feature/fix.js
+++ b/bin/cmd/feature/fix.js
@@ -1,0 +1,42 @@
+const fix = require('../../../whosonfirst/fix')
+const stream = {
+  json: require('../../../stream/json'),
+  miss: require('../../../stream/miss')
+}
+
+module.exports = {
+  command: 'fix',
+  describe: 'attempt to fix features in a stream',
+  builder: (yargs) => {
+    // optional params
+    yargs.option('concordances', {
+      type: 'boolean',
+      default: false,
+      describe: 'Fix missing concordances.'
+    })
+  },
+  handler: (argv) => {
+    let fixes = 0
+
+    // concordances fixes
+    if (argv.concordances) {
+      if (argv.verbose) { console.error('fixing missing concordances') }
+      fixes++
+    }
+
+    // ensure at least one fix is enabled
+    if (fixes < 1) {
+      console.error('you must enable at least one fix, see --help')
+      process.exit(1)
+    }
+
+    // process stream
+    process.stdin
+      .pipe(stream.json.parse())
+      .pipe(stream.miss.through.obj((feat, enc, next) => {
+        if (argv.concordances) { fix.concordances(feat) }
+        next(null, JSON.stringify(feat))
+      }))
+      .pipe(process.stdout)
+  }
+}

--- a/whosonfirst/fix.js
+++ b/whosonfirst/fix.js
@@ -1,0 +1,31 @@
+const _ = require('lodash')
+
+// mapping of property paths (on the left, using lodash path syntax)
+// and the corresponding key within the 'wof:concordances' object.
+const mapping = {
+  'qs_pg:gn_id': 'gn:id',
+  'qs_pg:qs_id': 'qs:id',
+  'qs:id': 'qs:id'
+}
+
+module.exports.concordances = (feat) => {
+  // map other concordances which may exist within the feature
+  // but only when not already present in 'wof:concordances'.
+  // note: take care with underscore vs. colon delimiters
+  _.each(mapping, (k, prop) => {
+    const source = `properties["${prop}"]`
+    const destination = `properties["wof:concordances"]["${k}"]`
+
+    // do not overwrite existing 'wof:concordances' values
+    if (_.has(feat, destination)) { return }
+
+    // find and validate properties
+    let v = _.get(feat, source)
+    if (!_.isString(v) && !_.isInteger(v)) { return }
+    if (_.isString(v)) { v = v.trim() }
+    if (_.isInteger(v) && v < 1) { return }
+
+    // write to 'wof:concordances'
+    _.set(feat, destination, v)
+  })
+}


### PR DESCRIPTION
Added a script which will fix missing properties in `wof:concordances` as per https://github.com/pelias/whosonfirst/pull/527

```bash
wof git clone --strategy=shallow whosonfirst-data-admin-sg /tmp/sg

wof git export /tmp/sg \
  | wof feature fix --concordances \
  | wof fs import --exportify /tmp/sg/data
```

related: https://github.com/whosonfirst-data/whosonfirst-data/issues/1956