### PR TITLE
fix is-current values in SPR table

### DIFF
--- a/sqlite/table/spr.test.js
+++ b/sqlite/table/spr.test.js
@@ -74,7 +74,7 @@ module.exports.insert = (test) => {
       min_longitude: 0,
       max_latitude: 0,
       max_longitude: 0,
-      is_current: 1,
+      is_current: -1,
       is_deprecated: 0,
       is_ceased: 0,
       is_superseded: 0,

--- a/whosonfirst/spr.js
+++ b/whosonfirst/spr.js
@@ -14,7 +14,7 @@ module.exports = (feat) => {
     country: feature.getCountry(feat),
     repo: feature.getRepo(feat),
     ...coordinates(feat),
-    is_current: feature.isCurrent(feat) ? 1 : 0,
+    is_current: feature.getIsCurrent(feat),
     is_deprecated: feature.isDeprecated(feat) ? 1 : 0,
     is_ceased: feature.isCeased(feat) ? 1 : 0,
     is_superseded: feature.isSuperseded(feat) ? 1 : 0,


### PR DESCRIPTION
Apparently the [mz:is_current](https://github.com/whosonfirst/whosonfirst-properties/blob/main/properties/mz/is_current.json) value can be `-1` 🤷‍♂️ 

I'm assuming that `-1` means 'unknown' as per other contexts where it's used, but I'm not sure if it really makes sense in the context of whether something is current or not, which seems to be a binary state.

This PR changes how the value for the `is_current` column of the `spr` table is generated.
Previously a value of `-1` was coerced to `1` which seems wrong and error-prone, so that's the main fix here.

I was tempted to change the `isCurrent()` helper in `whosonfirst/feature.js` too since it currently reads `feature.isCurrent = (feat) => feature.getIsCurrent(feat) !== 0`, but I think I'll do that in a subsequent PR.