### PR TITLE
fix(actions): bump gh actions ubuntu version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install node.js 14.x


### PR DESCRIPTION
the Github Actions Ubuntu version was no longer supported when running https://github.com/pelias/wof/runs/4508285522?check_suite_focus=true

I had to kill it manually, I'll re-run the publish step with this newer ubu version.