### PR TITLE
support names with extended 'private use' tags

### DIFF
--- a/sqlite/table/names.js
+++ b/sqlite/table/names.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const LanguageTag = require('rfc5646')
 const feature = require('../../whosonfirst/feature')
-const privateUseRegex = /^(.*)[_-]x[_-]([a-z]*)$/
+const privateUseRegex = /^(.*)[_-]x[_-]([a-z]*(_abbreviation)?)$/
 
 module.exports.create = (db) => {
   db.prepare(`

--- a/sqlite/table/names.test.js
+++ b/sqlite/table/names.test.js
@@ -57,7 +57,8 @@ module.exports.insert = (test) => {
       properties: {
         'name:ara_x_preferred': ['سانت جوليا دي لوريا'],
         'name:arg_x_variant': ['Sant Julià de Lòria'],
-        'name:bul_x_colloquial': ['Сан Джулия де Лория']
+        'name:bul_x_colloquial': ['Сан Джулия де Лория'],
+        'name:eng_x_preferred_abbreviation': ['ABBR']
       },
       geometry: {
         type: 'Point',
@@ -65,7 +66,7 @@ module.exports.insert = (test) => {
       }
     })
 
-    t.equals(db.stmt[0].action.run.length, 3)
+    t.equals(db.stmt[0].action.run.length, 4)
     t.deepEquals(db.stmt[0].action.run[0], [{
       language: 'ara',
       extlang: '',
@@ -103,6 +104,20 @@ module.exports.insert = (test) => {
       extension: '',
       privateuse: 'colloquial',
       name: 'Сан Джулия де Лория',
+      id: -1,
+      placetype: 'unknown',
+      country: 'XX',
+      lastmodified: -1
+    }])
+    t.deepEquals(db.stmt[0].action.run[3], [{
+      language: 'eng',
+      extlang: '',
+      script: undefined,
+      region: undefined,
+      variant: undefined,
+      extension: '',
+      privateuse: 'preferred_abbreviation',
+      name: 'ABBR',
       id: -1,
       placetype: 'unknown',
       country: 'XX',


### PR DESCRIPTION
such as `name:eng_x_preferred_abbreviation`
this is extremely rare but currently in-use by a couple dozen records, all with the `eng` prefix, eg:

```
101784551|locality|AT|eng|||||||Ried im Innkreis|1614387697
1158868591|county|CA|eng|||||||STRD|1582310118
1158868595|county|CA|eng|||||||Stikine RD|1642551747
890456453|county|CA|eng|||||||NCRD|1627521980
890456487|county|CA|eng|||||||CAPRD|1582310014
890456529|county|CA|eng|||||||RDEK|1582310004
890456813|county|CA|eng|||||||CRD|1582310015
890456815|county|CA|eng|||||||PORRD|1636414401
890456829|county|CA|eng|||||||SCRD|1636414396
890456837|county|CA|eng|||||||RDMW|1636414403
890456953|county|CA|eng|||||||SLRD|1627521984
890457193|county|CA|eng|||||||RDOS|1582310032
890457207|county|CA|eng|||||||PRRD|1642551805
890457209|county|CA|eng|||||||RDFFG|1642551733
890457249|county|CA|eng|||||||RDKB|1642551804
890457277|county|CA|eng|||||||CCRD|1636414414
890457467|county|CA|eng|||||||MVRD|1627521964
890457881|county|CA|eng|||||||RDN|1636414408
890458087|county|CA|eng|||||||BNRD|1642551823
890458089|county|CA|eng|||||||RDCK|1642551753
890458111|county|CA|eng|||||||RDKS|1627521952
890458113|county|CA|eng|||||||RDNO|1642551729
890458427|county|CA|eng|||||||RDCSH|1627521912
890458465|county|CA|eng|||||||TNRD|1627521984
890458565|county|CA|eng|||||||CMXRD|1642551794
890458567|county|CA|eng|||||||CVRD|1627521913
890458599|county|CA|eng|||||||RDAC|1627521908
890458697|county|CA|eng|||||||RDCO|1642551799
890458867|county|CA|eng|||||||FVRD|1582309941
```