### PR TITLE
sqlite: `concordances.other_id` column type

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@turf/bbox": "^6.0.1",
     "axios": "^0.21.1",
-    "better-sqlite3": "^7.4.3",
+    "better-sqlite3": "^8.3.0",
     "combine-streams": "^1.0.0",
     "command-exists": "^1.2.8",
     "csv-write-stream": "^2.0.0",

--- a/sqlite/table/concordances.js
+++ b/sqlite/table/concordances.js
@@ -5,7 +5,7 @@ module.exports.create = (db) => {
   db.prepare(`
     CREATE TABLE IF NOT EXISTS concordances (
       id INTEGER NOT NULL,
-      other_id INTEGER NOT NULL,
+      other_id TEXT NOT NULL,
       other_source TEXT,
       lastmodified INTEGER
   )`).run()


### PR DESCRIPTION
as reported in https://github.com/whosonfirst-data/whosonfirst-data/issues/2134 the `concordances.other_id` column type should be `TEXT` rather than `INTEGER` so it doesn't trim leading zeros.

```diff
< 102080625|2013|fips:code|1566609656
> 102080625|02013|fips:code|1566609656
```