### PR TITLE
add support for wof:placetype_alt

### DIFF
--- a/whosonfirst/feature.js
+++ b/whosonfirst/feature.js
@@ -34,4 +34,8 @@ feature.isCeased = (feat) => feature.getCessation(feat) !== 'uuuu'
 feature.isSuperseded = (feat) => !!feature.getSupersededBy(feat).length
 feature.isSuperseding = (feat) => !!feature.getSupersedes(feat).length
 
+// features may provide additional alternative placetypes
+// see: https://github.com/whosonfirst-data/whosonfirst-data/issues/2152
+feature.getAltPlacetypes = (feat) => _.castArray(_.get(feat, 'properties.wof:placetype_alt', []))
+
 module.exports = feature

--- a/whosonfirst/feature.test.js
+++ b/whosonfirst/feature.test.js
@@ -38,3 +38,16 @@ module.exports.getAltLabel = (test) => {
     t.end()
   })
 }
+
+module.exports.getAltPlacetypes = (test) => {
+  test('getAltPlacetypes', (t) => {
+    t.deepEqual([], feature.getAltPlacetypes({}))
+    t.deepEqual(['ALT_PLACETYPE'], feature.getAltPlacetypes({
+      properties: { 'wof:placetype_alt': 'ALT_PLACETYPE' }
+    }))
+    t.deepEqual(['ALT_PLACETYPE', 'ALT_PLACETYPE2'], feature.getAltPlacetypes({
+      properties: { 'wof:placetype_alt': ['ALT_PLACETYPE', 'ALT_PLACETYPE2'] }
+    }))
+    t.end()
+  })
+}

--- a/whosonfirst/view/_filters.js
+++ b/whosonfirst/view/_filters.js
@@ -3,7 +3,8 @@ const feature = require('../feature')
 
 // standard params filters
 function params (feat, params) {
-  if (!regex(_.get(params, 'placetype'), _.get(feat, 'properties.wof:placetype'))) return false
+  const placetypes = [feature.getPlacetype(feat), ...feature.getAltPlacetypes(feat)]
+  if (!contains(_.get(params, 'placetype'), placetypes)) return false
   if (!regex(_.get(params, 'geom'), _.get(feat, 'geometry.type'))) return false
 
   return true
@@ -26,4 +27,9 @@ function regex (pattern, match) {
   return new RegExp(`^${pattern}$`, 'i').test(match)
 }
 
-module.exports = { params, regex, exportable }
+function contains (needle, valid) {
+  if (!needle) return true
+  return valid.includes(needle)
+}
+
+module.exports = { params, regex, contains, exportable }


### PR DESCRIPTION
WOF features may belong to *multiple* placetypes, this PR adds support for the `wof:placetype_alt` property.

note: this is implemented in a 'view' so will currently only affect the `wof feature map` command when passed a `<script>` (ie. it will only really work for shapefile builds and not change any of the existing bundling code which traditionally didn't consider this field).

resolves https://github.com/whosonfirst-data/whosonfirst-data/issues/2152