### PR TITLE
Country <> Dependency IDs

### DIFF
--- a/whosonfirst/view/shapefile.js
+++ b/whosonfirst/view/shapefile.js
@@ -50,7 +50,8 @@ module.exports = (feat, params) => {
     /* extended properties */
     is_funky: _.get(feat, 'properties.mz:is_funky', ''),
     population: _.get(feat, 'properties.wof:population', ''),
-    country_id: _.get(feat, 'properties.wof:hierarchy[0].country_id', ''),
+    /* country and dependency are collectively "admin 0" for most general end users */
+    country_id: _.get(feat, 'properties.wof:hierarchy[0].country_id', _.get(feat, 'properties.wof:hierarchy[0].dependency_id', '')),
     region_id: _.get(feat, 'properties.wof:hierarchy[0].region_id', ''),
     county_id: _.get(feat, 'properties.wof:hierarchy[0].county_id', ''),
 


### PR DESCRIPTION
I'm trying to backfill `country_id` with `dependency_id` when `country_id` isn't available since these are interchangeable as "admin 0" to most folks.

:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

@missinglink I'm flying blind in Node.js land so I may have gotten this very wrong, please check me!