### PR TITLE
[WIP] Placetype local using English fallback and () latin names

### DIFF
--- a/whosonfirst/feature.js
+++ b/whosonfirst/feature.js
@@ -50,7 +50,14 @@ feature.getLocalLanguages = (feat, type = 'official') => {
 // see: https://github.com/whosonfirst-data/whosonfirst-data/issues/2154
 feature.getPlacetypeLocal = (feat) => _.flatten(
   feature.getLocalLanguages(feat, 'official')
+    // When a localized placetype isn't in a latin char set then WOF often provides
+    // a transliteration we can includesin a parenthetical, like: مقاطعة (muhafazah)
+    .map(lang => `label:${lang}_latn_x_preferred_placetype`)
+    // Otherwise prefer the local placetype name (assumes latin char set), like: provincia
     .map(lang => `label:${lang}_x_preferred_placetype`)
+    // Otherwise backfill with WOF's default English values, like: state
+    .concat(['label:eng_x_preferred_placetype'])
+    // Deprecated property, but sometimes a useful backfill
     .concat(['wof:placetype_local'])
     .map(prop => _.get(feat, `properties.${prop}`))
 ).filter(val => _.isString(val) && !_.isEmpty(val))


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

#### Here's the reason for this change :rocket:

Connected to WOF issue https://github.com/whosonfirst-data/whosonfirst-data/issues/2154, I'm fleshing out some more edge cases, namely 2 cases:

1. Sometimes the official language for a place is not in a latin character set, but WOF has (yet another) property that we can use to add a parenthetical so locales and non-locals can still read the value.
2. Sometimes there is no official language placetype translation, but there is an English preferred placetype. When that's available then backfill the exported property with the English value. 
    - NOTE: For the ~50k coarse admin places (country, dependency, macroregion, region, macrocounty, county) there is nearly 100% fill rate for `label:eng_x_preferred_placetype` because of recent WOF data work.

#### Here's what actually got changed :clap:

The code to calculate `getPlacetypeLocal` Shapefile property is extended with several new cases.

#### Here's how others can test the changes :eyes:

**Example features:**

- [Makkah](https://spelunker.whosonfirst.org/id/85676857/), Saudi Arabia
    - `lang:ara_x_preferred_placetype` =`مقاطعة`
    - `lang:ara_latn_x_preferred_placetype` = `muhafazah`
    - `lang:eng_x_preferred_placetype` = `region`
    - Expected `placelocal` value of `مقاطعة (muhafazah)`
- [Glasgow](https://spelunker.whosonfirst.org/id/1360698797/), Scotland, UK
    - `label:eng_x_preferred_placetype` = `unitary district`
    - `wof:placetype_local` = `unitary district`
    - Expected `placelocal` value of `unitary district`
- [Madrid](https://spelunker.whosonfirst.org/id/85682783/), province in Spain – 
    - `label:eng_x_preferred_placetype` = `province`
    - `label:spa_x_preferred_placetype` = `provincia`
    - `wof:placetype_local` = `autonomous community`
    - Expected `placelocal` value of `provincia`