### PR TITLE
Remove name constraint

### DIFF
--- a/whosonfirst/view/_filters.js
+++ b/whosonfirst/view/_filters.js
@@ -16,7 +16,6 @@ function exportable (feat, spr) {
   if (spr.id <= 0) return false
   if (spr.is_deprecated) return false
   if (spr.is_superseded) return false
-  if (spr.name.trim() === '') return false
   if (spr.latitude === 0.0 && spr.longitude === 0.0) return false
 
   return true


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

There are a tiny number of legit places without names. While excluding them makes sense for text based search, the visual map looks odd and buggy without these features.


I found this is true for United Kingdom at around 1% of `localadmin` features. I think its 0.01% in USA for same?

---
#### Here's how others can test the changes :eyes:

Example GB `localadmin` feature: `1360817295`.
