### PR TITLE
EDTF extended date parsing

### DIFF
--- a/whosonfirst/feature.js
+++ b/whosonfirst/feature.js
@@ -29,8 +29,8 @@ feature.getLastModified = (feat) => _.get(feat, 'properties.wof:lastmodified', -
 // boolean funcs
 feature.isAltGeometry = (feat) => !!feature.getAltLabel(feat)
 feature.isCurrent = (feat) => feature.getIsCurrent(feat) !== 0
-feature.isDeprecated = (feat) => feature.getDeprecated(feat) !== 'uuuu'
-feature.isCeased = (feat) => feature.getCessation(feat) !== 'uuuu'
+feature.isDeprecated = (feat) => /\d/.test(feature.getDeprecated(feat))
+feature.isCeased = (feat) => /\d/.test(feature.getCessation(feat))
 feature.isSuperseded = (feat) => !!feature.getSupersededBy(feat).length
 feature.isSuperseding = (feat) => !!feature.getSupersedes(feat).length
 

--- a/whosonfirst/feature.test.js
+++ b/whosonfirst/feature.test.js
@@ -122,3 +122,85 @@ module.exports.getPlacetypeLocal = (test) => {
     t.end()
   })
 }
+
+module.exports.isCeased = (test) => {
+  test('isCeased', (t) => {
+    t.false(feature.isCeased({}))
+
+    // unknown
+    t.false(feature.isCeased({
+      properties: { 'edtf:cessation': 'uuuu' }
+    }))
+    t.false(feature.isCeased({
+      properties: { 'edtf:cessation': '' }
+    }))
+
+    // open
+    t.false(feature.isCeased({
+      properties: { 'edtf:cessation': 'open' }
+    }))
+    t.false(feature.isCeased({
+      properties: { 'edtf:cessation': '..' }
+    }))
+
+    // dates
+    t.true(feature.isCeased({
+      properties: { 'edtf:cessation': '2023-02-13' }
+    }))
+    t.true(feature.isCeased({
+      properties: { 'edtf:cessation': '2024-02' }
+    }))
+    t.true(feature.isCeased({
+      properties: { 'edtf:cessation': '2006' }
+    }))
+    t.true(feature.isCeased({
+      properties: { 'edtf:cessation': '2018?' }
+    }))
+    t.true(feature.isCeased({
+      properties: { 'edtf:cessation': '1945~' }
+    }))
+
+    t.end()
+  })
+}
+
+module.exports.isDeprecated = (test) => {
+  test('isDeprecated', (t) => {
+    t.false(feature.isDeprecated({}))
+
+    // unknown
+    t.false(feature.isDeprecated({
+      properties: { 'edtf:deprecated': 'uuuu' }
+    }))
+    t.false(feature.isDeprecated({
+      properties: { 'edtf:deprecated': '' }
+    }))
+
+    // open
+    t.false(feature.isDeprecated({
+      properties: { 'edtf:deprecated': 'open' }
+    }))
+    t.false(feature.isDeprecated({
+      properties: { 'edtf:deprecated': '..' }
+    }))
+
+    // dates
+    t.true(feature.isDeprecated({
+      properties: { 'edtf:deprecated': '2023-02-13' }
+    }))
+    t.true(feature.isDeprecated({
+      properties: { 'edtf:deprecated': '2024-02' }
+    }))
+    t.true(feature.isDeprecated({
+      properties: { 'edtf:deprecated': '2006' }
+    }))
+    t.true(feature.isDeprecated({
+      properties: { 'edtf:deprecated': '2018?' }
+    }))
+    t.true(feature.isDeprecated({
+      properties: { 'edtf:deprecated': '1945~' }
+    }))
+
+    t.end()
+  })
+}


### PR DESCRIPTION
This PR resolves https://github.com/whosonfirst-data/whosonfirst-data/issues/2246

I originally intended to check for the strings `['uuuu', '', 'open', '..']` but ended up simply checking if the string contains a number, which has the benefit of working with all of these values without explicitly specifying them.

ref: https://mormonplaces.byu.edu/edtf.html