### PR TITLE
upgrade tar-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pretty-error": "^3.0.4",
     "require-all": "^3.0.0",
     "rfc5646": "^3.0.0",
-    "tar-stream": "^2.1.2",
+    "tar-stream": "^3.1.7",
     "tmp": "^0.1.0",
     "yargs": "^15.1.0"
   },


### PR DESCRIPTION
this PR bumps the version of [tar-stream](https://github.com/mafintosh/tar-stream/commits/master/) which has received a bunch of updates.

it's not clear exactly why the major version changed from 2->3 but I was able to confirm the API for packing tar files remains the same and works without error.