### PR TITLE
tippecanoe: allow oversize tiles

### DIFF
--- a/bin/cmd/feature/tippecanoe.js
+++ b/bin/cmd/feature/tippecanoe.js
@@ -66,6 +66,7 @@ module.exports = {
 function flags (argv) {
   return [
     '-zg', // automatically choose maxzoom
+    '--no-tile-size-limit', // allow oversize tiles
     '--projection=EPSG:4326',
     ...(argv.unlink ? ['--force'] : [])
   ]


### PR DESCRIPTION
configuration avoids tile size errors such as:

```
tile 2/1/1 size is 4265593 with detail 10, >500046
tile 2/0/1 size is 537180 with detail 7, >500461
could not make tile 2/0/1 small enough
tile 2/1/1 size is 2002584 with detail 9, >500137
tile 2/1/1 size is 832337 with detail 8, >500432
  24.8%  2/1/1


*** NOTE TILES ONLY COMPLETE THROUGH ZOOM 1 ***
```